### PR TITLE
Fixed `removeUselessStrokeAndFill` for fill

### DIFF
--- a/plugins/removeUselessStrokeAndFill.js
+++ b/plugins/removeUselessStrokeAndFill.js
@@ -51,13 +51,6 @@ exports.fn = function(item, params) {
                     item.removeAttr(attr.name);
                 }
             });
-
-            item.addAttr({
-                name: 'fill',
-                value: 'none',
-                prefix: '',
-                local: 'fill'
-            });
         }
 
     }


### PR DESCRIPTION
Hey,

I think this was for debug purposes, I removed it because it defeated the purpose of the plugin :)
